### PR TITLE
feat: improve alias options

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,3 @@
-// Auto-generated
-export * from '../index.js'
-
 export type Defaults = Record<string, unknown>
 
 export type Args<T = Defaults> = T & {
@@ -11,3 +8,6 @@ export interface Options {
   argv?: string[]
   alias?: Record<string, string | string[]>
 }
+
+// Auto-generated
+export * from '../index.js'

--- a/test/mix.test.ts
+++ b/test/mix.test.ts
@@ -10,13 +10,11 @@ test('args-mix', () => {
   }
 
   // $ hello world --foo bar -baz -cli demo --fuz
-  const args = createArgs<Args>({
+  const argsMix = createArgs<Args>({
     argv: ['hello', 'world', '--foo', 'bar', '-baz', '-cli', 'demo', '--fuz'],
   })
 
-  console.log(args)
-
-  expect(args).toStrictEqual({
+  expect(argsMix).toStrictEqual({
     _: ['hello', 'world'],
     foo: 'bar',
     baz: true,

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -11,16 +11,16 @@ test('args-options', () => {
     f?: boolean
   }
 
-  // $ --a value --d
-  const argsFlags = createArgs<Args>({
-    argv: ['--a', 'value', '--d'],
+  // $ --c value --e
+  const argsOptions = createArgs<Args>({
+    argv: ['--c', 'value', '--e'],
     alias: {
       a: ['b', 'c'],
       d: ['e', 'f'],
     },
   })
 
-  expect(argsFlags).toStrictEqual({
+  expect(argsOptions).toStrictEqual({
     _: [],
     a: 'value',
     b: 'value',


### PR DESCRIPTION

## Type of Change

- [x] New feature

## Request Description

Improves alias detection and updates tests accordingly.

Now the `parser` scans all the keys and values from the `alias` object and if they match the current argument, they will be specified in the final array.

Previously, only keys from object `alias` were scanned.

### Alias Options

```sh
$ --c value --e
```

```ts
const args = createArgs({
  alias: {
    a: ['b', 'c'], 
    d: ['e', 'f'], 
  },
})

/* Output:
{
    _: [],
    a: 'value',
    b: 'value',
    c: 'value',
    d: true,
    e: true,
    f: true,
}
*/
```